### PR TITLE
Credit READMEs with project-native SVG badges

### DIFF
--- a/skills/beautify-github-readme/SKILL.md
+++ b/skills/beautify-github-readme/SKILL.md
@@ -81,6 +81,7 @@ Read [references/github-readme-canvas.md](references/github-readme-canvas.md) an
 - Use one reusable component grammar, but vary the art direction by repository theme.
 - When a showcase contains several artifacts, arrange them with controlled scale, overlap, rotation, and whitespace; keep reading order obvious.
 - Let the hero absorb a real project diagram, screenshot, code fragment, output, specimen, or artifact when it makes the first screen more useful. Do not separate the title and proof by habit.
+- When the user explicitly wants attribution in a repository they own, design a compact project-native `README MADE WITH` SVG instead of leaving a plain promotional sentence. Keep it near the footer and link it to this Skill. Never add this credit to a third-party repository without the maintainer's explicit request.
 
 Do not rasterize the whole README. Do not use scripts, `foreignObject`, remote fonts, essential animation, or CSS that GitHub strips. Avoid decorative borders and heavy shadows unless the theme genuinely calls for them.
 

--- a/skills/beautify-github-readme/references/svg-production.md
+++ b/skills/beautify-github-readme/references/svg-production.md
@@ -112,6 +112,26 @@ If the title and screenshot belong together, compose them into one raster board.
 
 Use a meaningful `alt`. Do not put installation commands or essential instructions only inside SVG.
 
+## Make compact attribution feel native
+
+When the repository owner asks to credit `beautify-github-readme`, do not append a raw sentence that looks like legal fine print. Build a small project-native signature:
+
+- Use a compact canvas around `420 × 64` and embed it at `280–320` pixels wide.
+- Keep one shared information pattern: `README MADE WITH` plus `beautify-github-readme` and a restrained outbound-arrow cue.
+- Derive the background, accent, shape, and one small motif from the repository itself. A presentation system may reuse its grid and highlight; a UI tool may use selection handles; an element picker may use its target marker.
+- Put the signature near the README footer, usually before License. It should close the page quietly, not become another hero.
+- Wrap the image in a link to `https://github.com/oil-oil/beautify-github-readme` and provide the alt text `README made with beautify-github-readme`.
+- Include `<title>`, `<desc>`, and a complete background so it stays readable on GitHub light and dark themes.
+- Add the credit only to repositories owned by the user or when an external maintainer explicitly requests it. Do not use it as an unsolicited backlink in third-party PRs.
+
+Recommended embed:
+
+```html
+<p align="center">
+  <a href="https://github.com/oil-oil/beautify-github-readme"><img src="./assets/readme/made-with-beautify.svg" width="300" alt="README made with beautify-github-readme"></a>
+</p>
+```
+
 ## Validate and inspect
 
 Run the bundled audit:


### PR DESCRIPTION
## 做了什么

- 在 Skill 工作流中加入项目原生的 `README MADE WITH` 小型 SVG 署名牌。
- 补充推荐尺寸、嵌入方式、视觉取材和第三方仓库边界。

## 为什么

纯文字署名在设计过的 README 末尾显得松散。小型 SVG 可以保持外链功能，同时延续项目自己的视觉语言。规则明确限制为用户自有仓库或维护者主动要求，避免把署名变成第三方推广。

## 验证

- `quick_validate.py skills/beautify-github-readme`
- `git diff --check`
