### PR TITLE
Add oil-icon to real usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@
   <img src="./assets/readme/section-used-by.svg" width="100%" alt="这些 README 已经在使用 beautify-github-readme。">
 </p>
 
-这不是一组假想模板。下面三个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
+这不是一组假想模板。下面四个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** · 把程序化 PPT 的方法、效果和使用路径放在同一套视觉系统里。
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** · 用真实 UI 设计稿解释从需求、参考图到 HTML/CSS 还原的过程。
+- **[oil-icon](https://github.com/oil-oil/oil-icon)** · 用两套真实图标作品解释风格锁定、整套生成、切图与透明背景交付。
 - **[Selector](https://github.com/oil-oil/selector)** · 把网页选取、结构化上下文和实际输出直接放进首屏与示例。
 
 下面是四个独立的标题示例。它们不共用同一种风格，只根据项目本身决定字体、颜色和右侧放什么。

--- a/assets/readme/section-used-by.svg
+++ b/assets/readme/section-used-by.svg
@@ -1,14 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="150" viewBox="0 0 1200 150" role="img" aria-labelledby="title desc">
   <title id="title">这些 README 已经在使用</title>
-  <desc id="desc">oil-ppt、draw-ui 和 Selector 已经使用 beautify-github-readme 整理仓库主页。</desc>
+  <desc id="desc">oil-ppt、draw-ui、oil-icon 和 Selector 已经使用 beautify-github-readme 整理仓库主页。</desc>
   <rect width="1200" height="150" rx="28" fill="#F7F7F4"/>
   <path d="M0 45H1200M0 90H1200M120 0V150M240 0V150M360 0V150M480 0V150M600 0V150M720 0V150M840 0V150M960 0V150M1080 0V150" stroke="#E9E9E4" stroke-width="1"/>
   <text x="56" y="48" fill="#7B7E78" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">USED IN REAL REPOSITORIES</text>
   <rect x="56" y="66" width="58" height="5" rx="2.5" fill="#F3C737"/>
   <text x="56" y="120" fill="#171916" font-family="Arial, Helvetica, sans-serif" font-size="38" font-weight="800">这些 README 已经在使用</text>
-  <g transform="translate(940 42)" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800">
-    <rect width="74" height="44" rx="12" fill="#171916"/><text x="37" y="27" text-anchor="middle" fill="#FFF">PPT</text>
-    <rect x="86" width="74" height="44" rx="12" fill="#1677FF"/><text x="123" y="27" text-anchor="middle" fill="#FFF">UI</text>
-    <rect x="172" width="74" height="44" rx="12" fill="#F3C737"/><text x="209" y="27" text-anchor="middle" fill="#171916">DOM</text>
+  <g transform="translate(888 42)" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="800">
+    <rect width="62" height="44" rx="12" fill="#171916"/><text x="31" y="27" text-anchor="middle" fill="#FFF">PPT</text>
+    <rect x="72" width="62" height="44" rx="12" fill="#1677FF"/><text x="103" y="27" text-anchor="middle" fill="#FFF">UI</text>
+    <rect x="144" width="62" height="44" rx="12" fill="#1F7779"/><text x="175" y="27" text-anchor="middle" fill="#FFF">ICON</text>
+    <rect x="216" width="62" height="44" rx="12" fill="#F3C737"/><text x="247" y="27" text-anchor="middle" fill="#171916">DOM</text>
   </g>
 </svg>


### PR DESCRIPTION
## 做了什么

- 把 `oil-icon` 加入 README 的真实使用项目列表。
- 将章节标题右侧标识从三个扩展为 PPT、UI、ICON、DOM 四类。

## 为什么

oil-icon 的 README 现在也使用项目原生的 `beautify-github-readme` 签名牌，应当纳入真实使用列表，保持双向引用准确。

## 验证

- `python3 skills/beautify-github-readme/scripts/audit_readme.py README.md`
- `xmllint --noout assets/readme/section-used-by.svg`
- 本地渲染检查
- `git diff --check`
