### PR TITLE
docs: add codex-dev-team to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@
   <img src="./assets/readme/en/section-used-by.svg" width="100%" alt="Real repositories already using beautify-github-readme.">
 </p>
 
-These are not hypothetical templates. The method is already used by four public repositories, each with its own visual language and content structure:
+These are not hypothetical templates. The method is already used by six public repositories, each with its own visual language and content structure:
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** — presents the method, results, and first-use path for programmatic slide creation in one visual system.
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** — uses real UI outputs to explain the path from a brief and reference images to HTML/CSS reconstruction.
 - **[oil-icon](https://github.com/oil-oil/oil-icon)** — uses real icon sets to explain style locking, batch generation, slicing, and transparent delivery.
 - **[Selector](https://github.com/oil-oil/selector)** — puts page selection, structured context, and real output directly into the opening screen and examples.
+- **[codex-dev-team](https://github.com/oil-oil/codex-dev-team)** — uses a character-driven team map to explain how one main Codex thread delegates exploration, bounded implementation, and independent review to four custom agents.
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** — uses a project-native SVG hero with OBD-II PID data and a real dashboard screenshot to explain a self-hosted vehicle telemetry dashboard.
 
 If this Skill helped you create a public README you are proud of, you are welcome to propose it for this list in a PR. This is completely optional: the footer signature is appreciated but never required, and showcase submissions remain subject to maintainer review.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,12 +14,13 @@
   <img src="./assets/readme/section-used-by.svg" width="100%" alt="这些 README 已经在使用 beautify-github-readme。">
 </p>
 
-这不是一组假想模板。下面四个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
+这不是一组假想模板。下面六个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** · 把程序化 PPT 的方法、效果和使用路径放在同一套视觉系统里。
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** · 用真实 UI 设计稿解释从需求、参考图到 HTML/CSS 还原的过程。
 - **[oil-icon](https://github.com/oil-oil/oil-icon)** · 用两套真实图标作品解释风格锁定、整套生成、切图与透明背景交付。
 - **[Selector](https://github.com/oil-oil/selector)** · 把网页选取、结构化上下文和实际输出直接放进首屏与示例。
+- **[codex-dev-team](https://github.com/oil-oil/codex-dev-team)** · 用角色化团队图说明 Codex 主线程如何把代码探索、边界明确的实现和独立复审分给四个自定义 Agent。
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** · 用项目原生 SVG 标题和真实仪表盘截图，展示一个自托管车辆遥测仪表盘。
 
 如果这个 Skill 帮你做出了一份愿意公开分享的 README，欢迎通过 PR 申请加入这个列表。完全自愿：是否使用页尾脚标签名不影响申请，展示内容仍会经过维护者审核。

--- a/assets/readme/en/section-used-by.svg
+++ b/assets/readme/en/section-used-by.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="150" viewBox="0 0 1200 150" role="img" aria-labelledby="title desc">
   <title id="title">Already used in real READMEs</title>
-  <desc id="desc">oil-ppt, draw-ui, oil-icon, and Selector use beautify-github-readme.</desc>
+  <desc id="desc">Six public repositories use beautify-github-readme while keeping their own visual language.</desc>
   <rect width="1200" height="150" rx="28" fill="#F7F7F4"/>
   <path d="M0 45H1200M0 90H1200M120 0V150M240 0V150M360 0V150M480 0V150M600 0V150M720 0V150M840 0V150M960 0V150M1080 0V150" stroke="#E9E9E4" stroke-width="1"/>
   <text x="56" y="48" fill="#7B7E78" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">USED IN REAL REPOSITORIES</text>

--- a/assets/readme/section-used-by.svg
+++ b/assets/readme/section-used-by.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="150" viewBox="0 0 1200 150" role="img" aria-labelledby="title desc">
   <title id="title">这些 README 已经在使用</title>
-  <desc id="desc">oil-ppt、draw-ui、oil-icon 和 Selector 已经使用 beautify-github-readme 整理仓库主页。</desc>
+  <desc id="desc">六个公开仓库已经使用 beautify-github-readme 整理仓库主页，并保留各自的视觉语言。</desc>
   <rect width="1200" height="150" rx="28" fill="#F7F7F4"/>
   <path d="M0 45H1200M0 90H1200M120 0V150M240 0V150M360 0V150M480 0V150M600 0V150M720 0V150M840 0V150M960 0V150M1080 0V150" stroke="#E9E9E4" stroke-width="1"/>
   <text x="56" y="48" fill="#7B7E78" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">USED IN REAL REPOSITORIES</text>


### PR DESCRIPTION
Adds codex-dev-team to the English and Simplified Chinese showcase lists, corrects the repository count to six, and updates the SVG accessibility descriptions without adding more visual tiles.

Validated both READMEs with the bundled audit and checked the updated SVG files with xmllint.