### PR TITLE
docs: add shadybad to the real-world showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="./assets/readme/en/section-used-by.svg" width="100%" alt="Real repositories already using beautify-github-readme.">
 </p>
 
-These are not hypothetical templates. The method is already used by six public repositories, each with its own visual language and content structure:
+These are not hypothetical templates. The method is already used by seven public repositories, each with its own visual language and content structure:
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** — presents the method, results, and first-use path for programmatic slide creation in one visual system.
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** — uses real UI outputs to explain the path from a brief and reference images to HTML/CSS reconstruction.
@@ -22,6 +22,7 @@ These are not hypothetical templates. The method is already used by six public r
 - **[Selector](https://github.com/oil-oil/selector)** — puts page selection, structured context, and real output directly into the opening screen and examples.
 - **[codex-dev-team](https://github.com/oil-oil/codex-dev-team)** — uses a character-driven team map to explain how one main Codex thread delegates exploration, bounded implementation, and independent review to four custom agents.
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** — uses a project-native SVG hero with OBD-II PID data and a real dashboard screenshot to explain a self-hosted vehicle telemetry dashboard.
+- **[shadybad](https://github.com/shadybad)** — turns a GitHub profile README into a project-native agent-loop hero and matching section headers, with an animated GIF rendered from the SVG source.
 
 If this Skill helped you create a public README you are proud of, you are welcome to propose it for this list in a PR. This is completely optional: the footer signature is appreciated but never required, and showcase submissions remain subject to maintainer review.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
   <img src="./assets/readme/section-used-by.svg" width="100%" alt="这些 README 已经在使用 beautify-github-readme。">
 </p>
 
-这不是一组假想模板。下面六个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
+这不是一组假想模板。下面七个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** · 把程序化 PPT 的方法、效果和使用路径放在同一套视觉系统里。
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** · 用真实 UI 设计稿解释从需求、参考图到 HTML/CSS 还原的过程。
@@ -22,6 +22,7 @@
 - **[Selector](https://github.com/oil-oil/selector)** · 把网页选取、结构化上下文和实际输出直接放进首屏与示例。
 - **[codex-dev-team](https://github.com/oil-oil/codex-dev-team)** · 用角色化团队图说明 Codex 主线程如何把代码探索、边界明确的实现和独立复审分给四个自定义 Agent。
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** · 用项目原生 SVG 标题和真实仪表盘截图，展示一个自托管车辆遥测仪表盘。
+- **[shadybad](https://github.com/shadybad)** · 把 GitHub 个人主页 README 变成项目原生的 Agent Loop 标题和配套分节系统，并用 SVG 源渲染出动图。
 
 如果这个 Skill 帮你做出了一份愿意公开分享的 README，欢迎通过 PR 申请加入这个列表。完全自愿：是否使用页尾脚标签名不影响申请，展示内容仍会经过维护者审核。
 


### PR DESCRIPTION
Proposes adding the [shadybad](https://github.com/shadybad) GitHub profile README to the real-world showcase.

**Changes**
- Add one showcase entry to `README.md` and `README.zh-CN.md` (kept aligned).
- Update the repository count from six to seven in both languages.
- No SVG changes — `section-used-by`/`theme-wall` do not enumerate repositories.

**What the README demonstrates**
A GitHub profile README rebuilt around a project-native agent-loop hero (typed input → agent proposes → eval gate → human approves → engineer commits → reversible), matching SVG section headers, and a GitHub-safe animated GIF rendered from the SVG source.

Public repo, owned by me. Entirely optional — maintainers may edit, decline, or merge.