### PR TITLE
docs: add Dubbing-room to README showcase

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
   <img src="./assets/readme/en/section-used-by.svg" width="100%" alt="すでに beautify-github-readme を利用している実在のリポジトリ。">
 </p>
 
-これらは架空のテンプレートではありません。この手法はすでに 6 つの公開リポジトリで使われており、それぞれが独自のビジュアル言語とコンテンツ構成を備えています。
+これらは架空のテンプレートではありません。この手法はすでに 7 つの公開リポジトリで使われており、それぞれが独自のビジュアル言語とコンテンツ構成を備えています。
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** — プログラムによるスライド作成の手法、成果、最初の利用手順を、一つのビジュアルシステムで提示します。
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** — 実際の UI 出力を使い、要件と参照画像から HTML/CSS を再構築するまでの流れを説明します。
@@ -22,6 +22,7 @@
 - **[Selector](https://github.com/oil-oil/selector)** — ページ選択、構造化されたコンテキスト、実際の出力を、冒頭画面と例に直接配置します。
 - **[codex-dev-team](https://github.com/oil-oil/codex-dev-team)** — キャラクターを使ったチームマップにより、一つの Codex メインスレッドが探索、範囲を限定した実装、独立レビューを 4 つのカスタムエージェントへ委任する方法を説明します。
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** — OBD-II PID データを使ったプロジェクト固有の SVG ヒーローと実際のダッシュボード画面により、セルフホスト型の車両テレメトリーダッシュボードを紹介します。
+- **[Dubbing-room](https://github.com/Aoye-3/Dubbing-room)** — プロジェクト固有の SVG ヒーロー、実際のデスクトップ画面、デュアルモデルのワークフロー図を使い、VoxCPM2 による音声作成と IndexTTS2 による台詞表現がローカルの吹き替えスタジオをどう構成するかを示します。
 
 この Skill を使って公開したいと思える README を作成できた場合は、PR でこの一覧への追加を提案できます。これは完全に任意です。フッターへの署名は歓迎されますが必須ではなく、掲載の提案は引き続きメンテナーの審査対象です。
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="./assets/readme/en/section-used-by.svg" width="100%" alt="Real repositories already using beautify-github-readme.">
 </p>
 
-These are not hypothetical templates. The method is already used by six public repositories, each with its own visual language and content structure:
+These are not hypothetical templates. The method is already used by seven public repositories, each with its own visual language and content structure:
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** — presents the method, results, and first-use path for programmatic slide creation in one visual system.
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** — uses real UI outputs to explain the path from a brief and reference images to HTML/CSS reconstruction.
@@ -22,6 +22,7 @@ These are not hypothetical templates. The method is already used by six public r
 - **[Selector](https://github.com/oil-oil/selector)** — puts page selection, structured context, and real output directly into the opening screen and examples.
 - **[codex-dev-team](https://github.com/oil-oil/codex-dev-team)** — uses a character-driven team map to explain how one main Codex thread delegates exploration, bounded implementation, and independent review to four custom agents.
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** — uses a project-native SVG hero with OBD-II PID data and a real dashboard screenshot to explain a self-hosted vehicle telemetry dashboard.
+- **[Dubbing-room](https://github.com/Aoye-3/Dubbing-room)** — combines a project-native SVG hero, real desktop screenshots, and a dual-model workflow diagram to explain how VoxCPM2 voice creation and IndexTTS2 line performance form a local dubbing studio.
 
 If this Skill helped you create a public README you are proud of, you are welcome to propose it for this list in a PR. This is completely optional: the footer signature is appreciated but never required, and showcase submissions remain subject to maintainer review.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
   <img src="./assets/readme/section-used-by.svg" width="100%" alt="这些 README 已经在使用 beautify-github-readme。">
 </p>
 
-这不是一组假想模板。下面六个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
+这不是一组假想模板。下面七个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** · 把程序化 PPT 的方法、效果和使用路径放在同一套视觉系统里。
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** · 用真实 UI 设计稿解释从需求、参考图到 HTML/CSS 还原的过程。
@@ -22,6 +22,7 @@
 - **[Selector](https://github.com/oil-oil/selector)** · 把网页选取、结构化上下文和实际输出直接放进首屏与示例。
 - **[codex-dev-team](https://github.com/oil-oil/codex-dev-team)** · 用角色化团队图说明 Codex 主线程如何把代码探索、边界明确的实现和独立复审分给四个自定义 Agent。
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** · 用项目原生 SVG 标题和真实仪表盘截图，展示一个自托管车辆遥测仪表盘。
+- **[Dubbing-room](https://github.com/Aoye-3/Dubbing-room)** · 用项目原生 SVG 首屏、真实桌面截图和双模型工作流图，说明 VoxCPM2 声音创建与 IndexTTS2 台词表演如何组成一间本地配音室。
 
 如果这个 Skill 帮你做出了一份愿意公开分享的 README，欢迎通过 PR 申请加入这个列表。完全自愿：是否使用页尾脚标签名不影响申请，展示内容仍会经过维护者审核。
 

--- a/assets/readme/en/section-used-by.svg
+++ b/assets/readme/en/section-used-by.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="150" viewBox="0 0 1200 150" role="img" aria-labelledby="title desc">
   <title id="title">Already used in real READMEs</title>
-  <desc id="desc">Six public repositories use beautify-github-readme while keeping their own visual language.</desc>
+  <desc id="desc">Seven public repositories use beautify-github-readme while keeping their own visual language.</desc>
   <rect width="1200" height="150" rx="28" fill="#F7F7F4"/>
   <path d="M0 45H1200M0 90H1200M120 0V150M240 0V150M360 0V150M480 0V150M600 0V150M720 0V150M840 0V150M960 0V150M1080 0V150" stroke="#E9E9E4" stroke-width="1"/>
   <text x="56" y="48" fill="#7B7E78" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">USED IN REAL REPOSITORIES</text>

--- a/assets/readme/section-used-by.svg
+++ b/assets/readme/section-used-by.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="150" viewBox="0 0 1200 150" role="img" aria-labelledby="title desc">
   <title id="title">这些 README 已经在使用</title>
-  <desc id="desc">六个公开仓库已经使用 beautify-github-readme 整理仓库主页，并保留各自的视觉语言。</desc>
+  <desc id="desc">七个公开仓库已经使用 beautify-github-readme 整理仓库主页，并保留各自的视觉语言。</desc>
   <rect width="1200" height="150" rx="28" fill="#F7F7F4"/>
   <path d="M0 45H1200M0 90H1200M120 0V150M240 0V150M360 0V150M480 0V150M600 0V150M720 0V150M840 0V150M960 0V150M1080 0V150" stroke="#E9E9E4" stroke-width="1"/>
   <text x="56" y="48" fill="#7B7E78" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">USED IN REAL REPOSITORIES</text>


### PR DESCRIPTION
## Summary

- add [Dubbing-room](https://github.com/Aoye-3/Dubbing-room) to the real-world README showcase
- keep the English, Simplified Chinese, and Japanese showcase lists aligned
- update the accessible showcase count from six repositories to seven in the two section-used-by SVG descriptions

## Why

Dubbing-room used beautify-github-readme to reorganize its public repository homepage around a project-native SVG hero, real desktop screenshots, and a dual-model workflow diagram. The finished README explains how VoxCPM2 voice creation and IndexTTS2 line performance combine into a local dubbing studio.

## Verification

- the Dubbing-room README is published on its default branch
- this branch starts from the latest upstream main
- the branch is one commit ahead and zero commits behind upstream
- only the three localized README files and two accessible SVG descriptions change
- no attribution badge is required or added