### PR TITLE
docs: 把 wecom-qoder-bridge 加入 showcase 列表

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="./assets/readme/en/section-used-by.svg" width="100%" alt="Real repositories already using beautify-github-readme.">
 </p>
 
-These are not hypothetical templates. The method is already used by eight public repositories, each with its own visual language and content structure:
+These are not hypothetical templates. The method is already used by nine public repositories, each with its own visual language and content structure:
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** — presents the method, results, and first-use path for programmatic slide creation in one visual system.
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** — uses real UI outputs to explain the path from a brief and reference images to HTML/CSS reconstruction.
@@ -24,6 +24,7 @@ These are not hypothetical templates. The method is already used by eight public
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** — uses a project-native SVG hero with OBD-II PID data and a real dashboard screenshot to explain a self-hosted vehicle telemetry dashboard.
 - **[summertown](https://github.com/SummerPapaya/summertown)** — uses a seaside-map hero and landmark showcase to introduce an interactive town map.
 - **[Wolfcha](https://github.com/oil-oil/wolfcha)** — combines SVG typography and an AI-generated character cutout to turn “play Werewolf solo” into a cinematic, project-native opening screen.
+- **[wecom-qoder-bridge](https://github.com/painrice/wecom-qoder-bridge)** — uses a terminal-mock hero and a five-node system map to expose a local qoderclicn agent behind a WeCom smart bot without needing a public domain.
 
 If this Skill helped you create a public README you are proud of, you are welcome to propose it for this list in a PR. This is completely optional: the footer signature is appreciated but never required, and showcase submissions remain subject to maintainer review.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
   <img src="./assets/readme/section-used-by.svg" width="100%" alt="这些 README 已经在使用 beautify-github-readme。">
 </p>
 
-这不是一组假想模板。下面八个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
+这不是一组假想模板。下面九个仓库的 README 已经用这套方法重新整理过，每个项目保留自己的视觉语言和内容结构：
 
 - **[oil-ppt](https://github.com/oil-oil/oil-ppt)** · 把程序化 PPT 的方法、效果和使用路径放在同一套视觉系统里。
 - **[draw-ui](https://github.com/oil-oil/draw-ui)** · 用真实 UI 设计稿解释从需求、参考图到 HTML/CSS 还原的过程。
@@ -24,6 +24,7 @@
 - **[torqueDASH-Next](https://github.com/moesix/torque-dash-next)** · 用项目原生 SVG 标题和真实仪表盘截图，展示一个自托管车辆遥测仪表盘。
 - **[summertown](https://github.com/SummerPapaya/summertown)** · 用海滨地图主视觉和地标展示，介绍一个可交互的小镇地图。
 - **[Wolfcha](https://github.com/oil-oil/wolfcha)** · 用 SVG 排版与 AI 生成人物抠图，把“一个人也能玩狼人杀”做成电影感、项目原生的首屏。
+- **[wecom-qoder-bridge](https://github.com/painrice/wecom-qoder-bridge)** · 用终端 mock 做 hero、再用一张五节点系统图，讲清楚怎么让企微智能机器人直接调起本机 qoderclicn，全程不需要公网域名。
 
 如果这个 Skill 帮你做出了一份愿意公开分享的 README，欢迎通过 PR 申请加入这个列表。完全自愿：是否使用页尾脚标签名不影响申请，展示内容仍会经过维护者审核。
 

--- a/assets/readme/en/section-used-by.svg
+++ b/assets/readme/en/section-used-by.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="150" viewBox="0 0 1200 150" role="img" aria-labelledby="title desc">
   <title id="title">Already used in real READMEs</title>
-  <desc id="desc">Eight public repositories use beautify-github-readme while keeping their own visual language.</desc>
+  <desc id="desc">Nine public repositories use beautify-github-readme while keeping their own visual language.</desc>
   <rect width="1200" height="150" rx="28" fill="#F7F7F4"/>
   <path d="M0 45H1200M0 90H1200M120 0V150M240 0V150M360 0V150M480 0V150M600 0V150M720 0V150M840 0V150M960 0V150M1080 0V150" stroke="#E9E9E4" stroke-width="1"/>
   <text x="56" y="48" fill="#7B7E78" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">USED IN REAL REPOSITORIES</text>

--- a/assets/readme/section-used-by.svg
+++ b/assets/readme/section-used-by.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="150" viewBox="0 0 1200 150" role="img" aria-labelledby="title desc">
   <title id="title">这些 README 已经在使用</title>
-  <desc id="desc">八个公开仓库已经使用 beautify-github-readme 整理仓库主页，并保留各自的视觉语言。</desc>
+  <desc id="desc">九个公开仓库已经使用 beautify-github-readme 整理仓库主页，并保留各自的视觉语言。</desc>
   <rect width="1200" height="150" rx="28" fill="#F7F7F4"/>
   <path d="M0 45H1200M0 90H1200M120 0V150M240 0V150M360 0V150M480 0V150M600 0V150M720 0V150M840 0V150M960 0V150M1080 0V150" stroke="#E9E9E4" stroke-width="1"/>
   <text x="56" y="48" fill="#7B7E78" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">USED IN REAL REPOSITORIES</text>


### PR DESCRIPTION
## 摘要

把 wecom-qoder-bridge（@painrice）加入 beautify-github-readme 的"实际仓库"showcase 列表。

## 改动

4 个文件，6 处修改（4 处文案 + 2 处新条目）：

- `README.md`：`eight public repositories` → `nine public repositories`，并在 Wolfcha 之后新增一条 bullet
- `README.zh-CN.md`：`八个仓库` → `九个仓库`，对应中文 bullet
- `assets/readme/en/section-used-by.svg`：`<desc>` 中 `Eight` → `Nine`
- `assets/readme/section-used-by.svg`：`<desc>` 中 `八个` → `九个`

showcase SVG 的可视部分（4 个抽象类别标签 PPT/UI/ICON/DOM）未改动——它本身不列举具体仓库名，仅改 desc 文案保持准确性。

## 新条目文案

EN：

> **[wecom-qoder-bridge](https://github.com/painrice/wecom-qoder-bridge)** — uses a terminal-mock hero and a five-node system map to expose a local qoderclicn agent behind a WeCom smart bot without needing a public domain.

zh-CN：

> **[wecom-qoder-bridge](https://github.com/painrice/wecom-qoder-bridge)** · 用终端 mock 做 hero、再用一张五节点系统图，讲清楚怎么让企微智能机器人直接调起本机 qoderclicn，全程不需要公网域名。

## 仓库信息

- 仓库地址：https://github.com/painrice/wecom-qoder-bridge
- 仓库 owner / 维护者：@painrice（即本 PR 作者）
- 仓库状态：public
- README 已应用 beautify-github-readme hero + architecture SVG，单色技术风（GitHub 原生色板 + mono 字体 + terminal cursor 块 + WebSocket 脉冲）
- 已加 made-with 签名反向链接到本 skill

## 备注

完全自愿提交；如需调整描述措辞或排序，请直接在 PR 评论中指出。